### PR TITLE
Atualizacao e pequenos ajustes na pagina de citacoes do site oficial do data zoom ate jul26

### DIFF
--- a/_data/citacoes.yml
+++ b/_data/citacoes.yml
@@ -1,4 +1,9 @@
 published:
+  - author_date: "Haanwinckel, D. (2025)."
+    link: "https://www.aeaweb.org/articles?id=10.1257/aer.20201293"
+    title: "Supply, Demand, Institutions, and Firms: A Theory of Labor Market Sorting and the Wage Distribution"
+    remainder: "<em>American Economic Review, 115</em>(12), 4137–4182. https://doi.org/10.1257/aer.20201293. Data and code: https://www.openicpsr.org/openicpsr/project/221321/version/V1/view (includes <code>code/dependencies/DataZoom</code>)."
+
   - author_date: "Muniz, J., Queiroz, B. L., & Saperstein, A. (2024)."
     link: "https://www.demographic-research.org/articles/volume/50/17"
     title: "Racial classification as a multistate process"
@@ -28,16 +33,21 @@ published:
     link: "https://www.aeaweb.org/articles?id=10.1257/app.20170080"
     title: "Economic shocks and crime: Evidence from the Brazilian trade liberalization"
     remainder: "<em>American Economic Journal: Applied Economics, 10</em>(4), 158–195. https://doi.org/10.1257/app.20170080"
-unpublished:   
-  - author_date: "Ruhe, A. P. (2025)."
-    link: "https://anapaularuhe.github.io/LatestVersions/Draft%20-%20Labor%20markets%20dynamics%20with%20an%20informal%20sector.pdf"
-    title: "Labor market dynamics with an informal sector"
-    remainder: "Unpublished manuscript."
+unpublished:
+  - author_date: "Ruhe, A. P. (2026)."
+    link: "https://anapaularuhe.github.io/LatestVersions/Draft%20-%20Informality,%20heterogeneity,%20and%20the%20business%20cycle.pdf"
+    title: "Informality, Heterogeneity, and the Business Cycle"
+    remainder: "Job Market Paper. Unpublished manuscript."
 
-  - author_date: "Corbellini, N. (2024)."
-    link: "https://nicolacorbellini.github.io/assets/Job_Market_Paper.pdf"
-    title: "The effects of tax enforcement on the firm size distribution and aggregate productivity"
-    remainder: "Unpublished manuscript."
+  - author_date: "Zarate, P. (2025)."
+    link: "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5360652"
+    title: "Remote Work and Child Penalties"
+    remainder: "Working paper (Reject & Resubmit, <em>Journal of Human Resources</em>). https://doi.org/10.2139/ssrn.5360652"
+
+  - author_date: "Corbellini, N. (2025)."
+    link: "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5436436"
+    title: "The Effects of Tax Enforcement on Average Firm Size and Aggregate Productivity"
+    remainder: "Working paper. https://doi.org/10.2139/ssrn.5436436"    
 
   - author_date: "Oviedo, A. F. P., & Araújo, V. S. (2022)."
     link: "https://www.socioambiental.org/sites/default/files/noticias-e-posts/2022-10/Garimpo_final_IPS_2021.pdf"

--- a/_data/citacoes.yml
+++ b/_data/citacoes.yml
@@ -2,7 +2,7 @@ published:
   - author_date: "Haanwinckel, D. (2025)."
     link: "https://www.aeaweb.org/articles?id=10.1257/aer.20201293"
     title: "Supply, Demand, Institutions, and Firms: A Theory of Labor Market Sorting and the Wage Distribution"
-    remainder: "<em>American Economic Review, 115</em>(12), 4137–4182. https://doi.org/10.1257/aer.20201293. Data and code: https://www.openicpsr.org/openicpsr/project/221321/version/V1/view (includes <code>code/dependencies/DataZoom</code>)."
+    remainder: "<em>American Economic Review, 115</em>(12), 4137–4182. https://doi.org/10.1257/aer.20201293. Data and code: https://www.openicpsr.org/openicpsr/project/221321/version/V1/view%3Bjsessionid%3DE83776A2FB3CAC95F0EC8B33074AB659?path=%2Fopenicpsr%2F221321%2Ffcr%3Aversions%2FV1%2Fcode%2Fdependencies (includes <code>code/dependencies/DataZoom</code>)."
 
   - author_date: "Muniz, J., Queiroz, B. L., & Saperstein, A. (2024)."
     link: "https://www.demographic-research.org/articles/volume/50/17"

--- a/_data/citacoes.yml
+++ b/_data/citacoes.yml
@@ -2,7 +2,7 @@ published:
   - author_date: "Haanwinckel, D. (2025)."
     link: "https://www.aeaweb.org/articles?id=10.1257/aer.20201293"
     title: "Supply, Demand, Institutions, and Firms: A Theory of Labor Market Sorting and the Wage Distribution"
-    remainder: "<em>American Economic Review, 115</em>(12), 4137–4182. https://doi.org/10.1257/aer.20201293. <br>Data and code: https://www.openicpsr.org/openicpsr/project/221321/version/V1/view%3Bjsessionid%3DE83776A2FB3CAC95F0EC8B33074AB659?path=%2Fopenicpsr%2F221321%2Ffcr%3Aversions%2FV1%2Fcode%2Fdependencies."
+    remainder: "<em>American Economic Review, 115</em>(12), 4137–4182. https://doi.org/10.1257/aer.20201293 - [Data and code](https://www.openicpsr.org/openicpsr/project/221321/version/V1/view%3Bjsessionid%3DE83776A2FB3CAC95F0EC8B33074AB659?path=%2Fopenicpsr%2F221321%2Ffcr%3Aversions%2FV1%2Fcode%2Fdependencies)"
 
   - author_date: "Muniz, J., Queiroz, B. L., & Saperstein, A. (2024)."
     link: "https://www.demographic-research.org/articles/volume/50/17"

--- a/_data/citacoes.yml
+++ b/_data/citacoes.yml
@@ -2,7 +2,7 @@ published:
   - author_date: "Haanwinckel, D. (2025)."
     link: "https://www.aeaweb.org/articles?id=10.1257/aer.20201293"
     title: "Supply, Demand, Institutions, and Firms: A Theory of Labor Market Sorting and the Wage Distribution"
-    remainder: "<em>American Economic Review, 115</em>(12), 4137–4182. https://doi.org/10.1257/aer.20201293. Data and code: https://www.openicpsr.org/openicpsr/project/221321/version/V1/view%3Bjsessionid%3DE83776A2FB3CAC95F0EC8B33074AB659?path=%2Fopenicpsr%2F221321%2Ffcr%3Aversions%2FV1%2Fcode%2Fdependencies (includes <code>code/dependencies/DataZoom</code>)."
+    remainder: "<em>American Economic Review, 115</em>(12), 4137–4182. https://doi.org/10.1257/aer.20201293. <br>Data and code: https://www.openicpsr.org/openicpsr/project/221321/version/V1/view%3Bjsessionid%3DE83776A2FB3CAC95F0EC8B33074AB659?path=%2Fopenicpsr%2F221321%2Ffcr%3Aversions%2FV1%2Fcode%2Fdependencies."
 
   - author_date: "Muniz, J., Queiroz, B. L., & Saperstein, A. (2024)."
     link: "https://www.demographic-research.org/articles/volume/50/17"

--- a/en/citacao.md
+++ b/en/citacao.md
@@ -20,6 +20,22 @@ pre {
   cursor: pointer; /* Shows it's clickable */
   user-select: all;
 }
+
+.scroll-box h3 {
+  font-size: 1.4em;
+  margin-top: 2em;
+  margin-bottom: 1em;
+}
+
+.scroll-box h3:first-of-type {
+  margin-top: 0.5em;
+}
+
+.scroll-box p {
+  margin-bottom: 1.5em;
+}
+  
+  
 </style>
 
 # Cite Data Zoom in your research

--- a/en/citacao.md
+++ b/en/citacao.md
@@ -21,6 +21,12 @@ pre {
   user-select: all;
 }
 
+.scroll-box {
+  width: 100% !important;
+  max-width: 100% !important;
+  box-sizing: border-box;
+}
+  
 .scroll-box h3 {
   font-size: 1.4em;
   margin-top: 2em;
@@ -76,7 +82,7 @@ In case Data Zoom has helped in a study you've written, please send a copy to [d
       <a href="{{ paper.link }}" target="_blank" rel="noopener noreferrer">
         <em>{{ paper.title }}</em>
       </a>.
-    {{ paper.remainder }}
+    {{ paper.remainder | markdownify | remove: "<p>" | remove: "</p>" }}
     </p>
   {% endfor %}
   <h3> Working papers and other texts </h3>

--- a/pt/citacao.md
+++ b/pt/citacao.md
@@ -81,7 +81,7 @@ Caso o Data Zoom tenha ajudado em algum estudo escrito por você, pedimos que en
       <a href="{{ paper.link }}" target="_blank" rel="noopener noreferrer">
         <em>{{ paper.title }}</em>
       </a>.
-    {{ paper.remainder }}
+    {{ paper.remainder | markdownify | remove: "<p>" | remove: "</p>" }}
     </p>
   {% endfor %}
   <h3> Working papers e outros textos </h3>

--- a/pt/citacao.md
+++ b/pt/citacao.md
@@ -21,6 +21,12 @@ pre {
   user-select: all;
 }
 
+.scroll-box {
+  width: 100% !important;
+  max-width: 100% !important;
+  box-sizing: border-box;
+}
+  
 .scroll-box h3 {
   font-size: 1.4em;
   margin-top: 2em;

--- a/pt/citacao.md
+++ b/pt/citacao.md
@@ -7,6 +7,19 @@ lang: pt
 <style>
 #output pre { display: none; }
 #output pre#bibtex { display: block; }
+  
+pre {
+  border: 2px solid #369; /* Blue border, change color as you like */
+  border-radius: 6px;         /* Rounded corners */
+  padding: 1em;               /* Space inside the border */
+  background-color: #ecf1f5; /* Light blue background */
+  font-family: monospace;
+  font-size: 0.9em;
+  white-space: pre-wrap;  /* wraps long lines */
+  word-wrap: break-word;  /* breaks long words if needed */
+  cursor: pointer; /* Shows it's clickable */
+  user-select: all;
+}
 
 .scroll-box h3 {
   font-size: 1.4em;
@@ -22,18 +35,6 @@ lang: pt
   margin-bottom: 1.5em;
 }
   
-pre {
-  border: 2px solid #369; /* Blue border, change color as you like */
-  border-radius: 6px;         /* Rounded corners */
-  padding: 1em;               /* Space inside the border */
-  background-color: #ecf1f5; /* Light blue background */
-  font-family: monospace;
-  font-size: 0.9em;
-  white-space: pre-wrap;  /* wraps long lines */
-  word-wrap: break-word;  /* breaks long words if needed */
-  cursor: pointer; /* Shows it's clickable */
-  user-select: all;
-}
 </style>
 
 # Cite o Data Zoom em sua pesquisa

--- a/pt/citacao.md
+++ b/pt/citacao.md
@@ -8,6 +8,20 @@ lang: pt
 #output pre { display: none; }
 #output pre#bibtex { display: block; }
 
+.scroll-box h3 {
+  font-size: 1.4em;
+  margin-top: 2em;
+  margin-bottom: 1em;
+}
+
+.scroll-box h3:first-of-type {
+  margin-top: 0.5em;
+}
+
+.scroll-box p {
+  margin-bottom: 1.5em;
+}
+  
 pre {
   border: 2px solid #369; /* Blue border, change color as you like */
   border-radius: 6px;         /* Rounded corners */


### PR DESCRIPTION
Atualiza a pagina de citacoes do site oficial do data zoom:

adiciona 2 papers (um publicado na AER e um working paper), e atualiza a referencia de 2 working paper;
adiciona maior espacamento entre os papers citados e entre as categorias de papers, com aumento dos titulos que se referem as categorias;
Aumenta a largura das caixas para que acompanhem os textos fora das caixas